### PR TITLE
Add projects using SPDX license ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # SPDX Adoption
 
 Projects known to use SPDX headers: 
-* [Das U-Boot](https://www.denx.de/wiki/U-Boot)
+* The [Linux kernel](https://www.kernel.org/doc/html/latest/process/license-rules.html#license-identifier-syntax) ([LWN article](https://lwn.net/Articles/739183/))
+* The [Zephyr Project](https://www.zephyrproject.org/) ([example](https://github.com/zephyrproject-rtos/zephyr/blob/master/zephyr-env.sh))
+* Several [Hyperledger](https://hyperledger.org/) projects, including [Hyperledger Fabric](https://github.com/hyperledger/fabric/blob/19edb32647bc68b7a877f5d00beb609c8a044544/docs/source/dev-setup/headers.txt) and [Hyperledger Iroha](https://github.com/hyperledger/iroha/blob/ed665deb84aba285e2dfc217188bba8a9cc5ce2e/example/node/index.js)
+* [POCO](https://github.com/pocoproject/poco/blob/develop/LICENSE)
+* [Arm Mbed](https://github.com/ARMmbed)
+* [Das U-Boot](https://www.denx.de/wiki/U-Boot) ([example](http://git.denx.de/?p=u-boot.git;a=blob_plain;f=README;hb=HEAD))
+* NPM packages: [spdx-license-ids](https://www.npmjs.com/package/spdx-license-ids) and [spdx](https://www.npmjs.com/package/spdx)
+* [Tern](https://github.com/vmware/tern)
+* [yotta](http://docs.yottabuild.org/reference/licenses.html)
 
 Projects known to generate SPDX documents with releases:  


### PR DESCRIPTION
Adds the projects and links currently at https://spdx.org/ids-where

cc @kestewart 