### PR TITLE
updated POCO project license location

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Projects known to use SPDX headers:
 * The [Linux kernel](https://www.kernel.org/doc/html/latest/process/license-rules.html#license-identifier-syntax) ([LWN article](https://lwn.net/Articles/739183/))
 * The [Zephyr Project](https://www.zephyrproject.org/) ([example](https://github.com/zephyrproject-rtos/zephyr/blob/master/zephyr-env.sh))
 * Several [Hyperledger](https://hyperledger.org) projects, including [Hyperledger Fabric](https://github.com/hyperledger/fabric/blob/19edb32647bc68b7a877f5d00beb609c8a044544/docs/source/dev-setup/headers.txt) and [Hyperledger Iroha](https://github.com/hyperledger/iroha/blob/ed665deb84aba285e2dfc217188bba8a9cc5ce2e/example/node/index.js)
-* [POCO](https://github.com/pocoproject/poco/blob/develop/LICENSE)
+* [POCO](https://github.com/pocoproject/poco/blob/devel/LICENSE)
 * [Arm Mbed](https://github.com/ARMmbed)
 * NPM packages: [spdx-license-ids](https://www.npmjs.com/package/spdx-license-ids) and [spdx](https://www.npmjs.com/package/spdx)
 * [Tern](https://github.com/vmware/tern)


### PR DESCRIPTION
The poco project license moved to a different location. The current link is broken.